### PR TITLE
monkeypatch int64 support

### DIFF
--- a/src/types/number.js
+++ b/src/types/number.js
@@ -136,7 +136,8 @@ class MappingNumber extends MappingRange {
 
   get numericFormat() {
     return {
-      integer: "integer"
+      integer: "integer",
+      int64: "long"
     };
   }
 


### PR DESCRIPTION
For posterity:

I say monkey-patch because type: integer, format: int64 is not officially supported JSON-schema and the error likely is really with the schema we present. That said, this patch is ready and will not make the API and more incorrect since the ElasticSearch the improper JSONschema is converted to is correct.

In the future I would like to follow the unofficial expanded formats specified by Google's API discovery service [here](https://developers.google.com/discovery/v1/type-format). Because in implementation nearly every JSON library interprets JSON number as a double so it would be capped at 2^52 which would make it unwise to send and return 64bit integers as JSON numbers. The proposed solution is to send them as strings with an int64 format (i.e type: string, format: int64)